### PR TITLE
Prevent NPE in VersiondebtMojo and Versiondebts

### DIFF
--- a/versiondebt-maven-plugin/src/main/java/com/portofrotterdam/versiondebt/VersiondebtMojo.java
+++ b/versiondebt-maven-plugin/src/main/java/com/portofrotterdam/versiondebt/VersiondebtMojo.java
@@ -246,14 +246,17 @@ public class VersiondebtMojo extends AbstractMojo {
             e1.printStackTrace();
         }
         final Metadata repoMetadata = metadata.getMetadata();
-        final String releasedVersion = repoMetadata.getVersioning().getRelease();
-        if (releasedVersion != null) {
-            return releasedVersion;
+        if (repoMetadata.getVersioning() != null) {
+            final String releasedVersion = repoMetadata.getVersioning().getRelease();
+            if (releasedVersion != null) {
+                return releasedVersion;
+            }
+            final String latestVersion = repoMetadata.getVersioning().getLatest();
+            if (latestVersion != null) {
+                return latestVersion;
+            }
         }
-        final String latestVersion = repoMetadata.getVersioning().getLatest();
-        if (latestVersion != null) {
-            return latestVersion;
-        }
+
         return repoMetadata.getVersion();
     }
 

--- a/versiondebt-shared/src/main/java/com/portofrotterdam/versiondebt/Versiondebts.java
+++ b/versiondebt-shared/src/main/java/com/portofrotterdam/versiondebt/Versiondebts.java
@@ -44,7 +44,11 @@ public class Versiondebts implements Serializable {
 	}
 
 	public List<VersiondebtItem> getVersiondebtItems() {
-		return Collections.unmodifiableList(new ArrayList<>(versiondebtItems));
+		if (versiondebtItems != null) {
+			return Collections.unmodifiableList(new ArrayList<>(versiondebtItems));
+		} else {
+			return Collections.emptyList();
+		}
 	}
 
 	@XStreamAlias("versiondebtItem")


### PR DESCRIPTION
Found these 2 NPEs when playing with https://github.com/jbossws/jbossws-cxf (tag jbossws-cxf-5.1.5.Final)

To be sure I do not have compromised local repo I executed `mvn -e -s ~/TESTING/settings.xml -Dmaven.repo.local=/home/rsvoboda/Downloads/local-repo versiondebt:generate | tee ~/Downloads/log.txt`

`mvn -version`
> Apache Maven 3.3.9 (bb52d8502b132ec0a5a3f4c09453c07478323dc5; 2015-11-10T17:41:47+01:00)
Maven home: /opt/maven
Java version: 1.8.0_91, vendor: Oracle Corporation
Java home: /opt/jdk1.8.0_91/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "4.8.8-300.fc25.x86_64", arch: "amd64", family: "unix"

In `~/TESTING/settings.xml` I have enabled Central plus following repos:
 * http://repository.jboss.org/nexus/content/groups/public/
 * http://repository.jboss.org/nexus/content/repositories/releases/